### PR TITLE
Added missing PreventUpdate import for no_update callbacks.

### DIFF
--- a/dash_dict_callback/__init__.py
+++ b/dash_dict_callback/__init__.py
@@ -3,6 +3,7 @@ from functools import wraps, partial
 from types import MethodType
 from collections.abc import Iterable
 from dash.dependencies import Output, Input, State
+from dash.exceptions import PreventUpdate
 
 class _DashDictCallbackPlugin():
     class callback_dict(dict):


### PR DESCRIPTION
**Issue**
Returning `dash.no_update` in a callback throws a `NameError: name 'PreventUpdate' is not defined` exception.

**Reason**
`__init__.py` is missing the `PreventUpdate` import from `dash.exceptions`.

**Fix**
Added the import to `__init__.py`.